### PR TITLE
Export Command and Cli types

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,18 @@ package main
 import "github.com/adampointer/cali"
 
 func main() {
-	cli := cali.Cli("cali")
+	cli := cali.NewCli("cali")
 	cli.SetShort("Example CLI tool")
 	cli.SetLong("A nice long description of what your tool actually does")
 
-	terraform := cli.Command("terraform [command]")
+	cmdTerraform(cli)
+
+	cli.Start()
+}
+
+func cmdTerraform(cli *cali.Cli) {
+
+	terraform := cli.NewCommand("terraform [command]")
 	terraform.SetShort("Run Terraform in an ephemeral container")
 	terraform.SetLong(`Starts a container for Terraform and attempts to run it against your code. There are two choices for code source; a local mount, or directly from a git repo.
 
@@ -64,8 +71,6 @@ Examples:
 	terraformTask.SetInitFunc(func(t *cali.Task, args []string) {
 		t.AddEnv("AWS_PROFILE", cli.FlagValues().GetString("profile"))
 	})
-
-	cli.Start()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This has been a great success and we are really happy with how it works and how 
 ```
 package main
 
-import "github.com/adampointer/cali"
+import "github.com/skybet/cali"
 
 func main() {
 	cli := cali.NewCli("cali")


### PR DESCRIPTION
Allows code which consumes this library to refer to *cali.Cli and *cali.Command
in function definitions (thereby allowing subcommands to be defined in separate
files to the parent command)