### PR TITLE
User friendly git container names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.8
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/skybet/cali
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+[Unreleased]: https://github.com/skybet/cali/compare/v0.1.0...master
+[0.1.0]:      https://github.com/skybet/cali/compare/init...v0.1.0
+
+## [Unreleased]
+### Added
+- This CHANGELOG file
+
+### Changed
+- Git data containers now have the repo name, branch and directory in the container name
+
+
+## [0.1.0] - 2018-02-03
+### Added
+- Tagged a stable version of Cali which devs can pin to

--- a/git_test.go
+++ b/git_test.go
@@ -1,0 +1,12 @@
+package cali
+
+import (
+	"testing"
+)
+
+func TestGetContainerName(t *testing.T) {
+
+}
+
+func TestRepoNameFromUrl(t *testing.T) {
+}

--- a/git_test.go
+++ b/git_test.go
@@ -2,11 +2,48 @@ package cali
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetContainerName(t *testing.T) {
+	t.Log("Testing simple example")
+	name, err := GitCheckoutConfig{
+		Repo:    "repo",
+		Branch:  "branch",
+		RelPath: ".",
+	}.GetContainerName()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "data_repo_._branch_89bb6900736548ebd6455d0ab07aa5fe", name)
+	}
 
+	t.Log("Testing branches and paths with slashes")
+	name, err = GitCheckoutConfig{
+		Repo:    "repo",
+		Branch:  "branch/with-slash",
+		RelPath: "path/containing/slashes",
+	}.GetContainerName()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "data_repo_path-containing-slashes_branch-with-slash_89bb6900736548ebd6455d0ab07aa5fe", name)
+	}
 }
 
 func TestRepoNameFromUrl(t *testing.T) {
+	t.Log("Testing an example git url")
+	name, err := repoNameFromUrl("git@github.com:skybet/cali.git")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "github-com-skybet-cali", name)
+	}
+
+	t.Log("Testing an example https url")
+	name, err = repoNameFromUrl("https://github.com/skybet/cali.git")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "github-com-skybet-cali", name)
+	}
+
+	t.Log("Testing an example git url with ssh protocol")
+	name, err = repoNameFromUrl("ssh://git@github.com/skybet/cali.git")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "github-com-skybet-cali", name)
+	}
 }

--- a/git_test.go
+++ b/git_test.go
@@ -7,17 +7,36 @@ import (
 )
 
 func TestGetContainerName(t *testing.T) {
-	t.Log("Testing simple example")
+	t.Log("Simple example")
 	name, err := GitCheckoutConfig{
 		Repo:    "repo",
 		Branch:  "branch",
 		RelPath: ".",
 	}.GetContainerName()
 	if assert.NoError(t, err) {
-		assert.Equal(t, "data_repo_._branch_89bb6900736548ebd6455d0ab07aa5fe", name)
+		assert.Equal(t, "data_repo_branch_89bb6900736548ebd6455d0ab07aa5fe", name)
 	}
 
-	t.Log("Testing branches and paths with slashes")
+	t.Log("Simple example, with empty path")
+	name, err = GitCheckoutConfig{
+		Repo:    "repo",
+		Branch:  "branch",
+		RelPath: "",
+	}.GetContainerName()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "data_repo_branch_89bb6900736548ebd6455d0ab07aa5fe", name)
+	}
+
+	t.Log("Simple example, with unspecified path")
+	name, err = GitCheckoutConfig{
+		Repo:   "repo",
+		Branch: "branch",
+	}.GetContainerName()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "data_repo_branch_89bb6900736548ebd6455d0ab07aa5fe", name)
+	}
+
+	t.Log("Branches and paths with slashes")
 	name, err = GitCheckoutConfig{
 		Repo:    "repo",
 		Branch:  "branch/with-slash",
@@ -29,19 +48,19 @@ func TestGetContainerName(t *testing.T) {
 }
 
 func TestRepoNameFromUrl(t *testing.T) {
-	t.Log("Testing an example git url")
+	t.Log("Example git url")
 	name, err := repoNameFromUrl("git@github.com:skybet/cali.git")
 	if assert.NoError(t, err) {
 		assert.Equal(t, "github-com-skybet-cali", name)
 	}
 
-	t.Log("Testing an example https url")
+	t.Log("Example https url")
 	name, err = repoNameFromUrl("https://github.com/skybet/cali.git")
 	if assert.NoError(t, err) {
 		assert.Equal(t, "github-com-skybet-cali", name)
 	}
 
-	t.Log("Testing an example git url with ssh protocol")
+	t.Log("Example git url with ssh protocol")
 	name, err = repoNameFromUrl("ssh://git@github.com/skybet/cali.git")
 	if assert.NoError(t, err) {
 		assert.Equal(t, "github-com-skybet-cali", name)


### PR DESCRIPTION
e.g.

```
--git lucymhdavies@bitbucket.org:lmhd/rancher.git --git-path 001.infrastructure
```

results in

```
data_lucymhdavies-bitbucket-org-lmhd-rancher-git_001.infrastructure_master_c0475003758c094d215173f9c5e2a958
```

Whereas before it was only:

```
data_8406bb4c2e44fc2ddf1c1bce64f34626
```

----

Deliberately opening this PR now, while the tests fail, just to verify it behaves as expected in Circle and GitHub.