### PR TITLE
Moved classes to their own files

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -3,14 +3,10 @@ package cali
 import (
 	"fmt"
 	"os"
-	"os/user"
-	"path/filepath"
 	"runtime"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -45,142 +41,8 @@ var defaultTaskFunc TaskFunc = func(t *Task, args []string) {
 	}
 }
 
-// Task is the action performed when it's parent command is run
-type Task struct {
-	f, init TaskFunc
-	*DockerClient
-}
-
-// SetFunc sets the TaskFunc which is run when the parent command is run
-// if this is left unset, the defaultTaskFunc will be executed instead
-func (t *Task) SetFunc(f TaskFunc) {
-	t.f = f
-}
-
-// SetInitFunc sets the TaskFunc which is executed before the main TaskFunc. It's
-// pupose is to do any setup of the DockerClient which depends on command line args
-// for example
-func (t *Task) SetInitFunc(f TaskFunc) {
-	t.init = f
-}
-
-// SetDefaults sets the default host config for a task container
-// Mounts the PWD to /tmp/workspace
-// Mounts your ~/.aws directory to /root - change this if your image runs as a non-root user
-// Sets /tmp/workspace as the workdir
-// Configures git
-func (t *Task) SetDefaults(args []string) error {
-	t.SetWorkDir(workdir)
-	awsDir, err := t.Bind("~/.aws", "/root/.aws")
-	if err != nil {
-		return err
-	}
-	t.AddBinds([]string{awsDir})
-
-	err = t.BindFromGit(gitCfg, func() error {
-		pwd, err := t.Bind("./", workdir)
-		if err != nil {
-			return err
-		}
-		t.AddBinds([]string{pwd})
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	t.SetCmd(args)
-	return nil
-}
-
-// Bind is a utility function which will return the correctly formatted string when given a source
-// and destination directory
-//
-// The ~ symbol and relative paths will be correctly expanded depending on the host OS
-func (t *Task) Bind(src, dst string) (string, error) {
-	var expanded string
-
-	if strings.HasPrefix(src, "~") {
-		usr, err := user.Current()
-
-		if err != nil {
-			return expanded, fmt.Errorf("Error expanding bind path: %s")
-		}
-		expanded = filepath.Join(usr.HomeDir, src[2:])
-	} else {
-		expanded = src
-	}
-	expanded, err := filepath.Abs(expanded)
-
-	if err != nil {
-		return expanded, fmt.Errorf("Error expanding bind path: %s")
-	}
-	return fmt.Sprintf("%s:%s", expanded, dst), nil
-}
-
 // cobraFunc represents the function signiture which cobra uses for it's Run, PreRun, PostRun etc.
 type cobraFunc func(cmd *cobra.Command, args []string)
-
-// command is the actual command run by the cli and essentially just wraps cobra.Command and
-// has an associated Task
-type Command struct {
-	name    string
-	RunTask *Task
-	cobra   *cobra.Command
-}
-
-// SetShort sets the short description of the command
-func (c *Command) SetShort(s string) {
-	c.cobra.Short = s
-}
-
-// SetLong sets the long description of the command
-func (c *Command) SetLong(l string) {
-	c.cobra.Long = l
-}
-
-// setPreRun sets the cobra.Command.PreRun function
-func (c *Command) setPreRun(f cobraFunc) {
-	c.cobra.PreRun = f
-}
-
-// setRun sets the cobra.Command.Run function
-func (c *Command) setRun(f cobraFunc) {
-	c.cobra.Run = f
-}
-
-// Task is something executed by a command
-func (c *Command) Task(def interface{}) *Task {
-	t := &Task{DockerClient: NewDockerClient()}
-
-	switch d := def.(type) {
-	case string:
-		t.SetImage(d)
-		t.SetFunc(defaultTaskFunc)
-	case TaskFunc:
-		t.SetFunc(d)
-	default:
-		// Slightly unidiomatic to blow up here rather than return an error
-		// choosing to so as to keep the API uncluttered and also if you get here it's
-		// an implementation error rather than a runtime error.
-		fmt.Println("Unknown Task type. Must either be an image (string) or a TaskFunc")
-		os.Exit(EXIT_CODE_API_ERROR)
-	}
-	c.RunTask = t
-	return t
-}
-
-// Flags returns the FlagSet for the command and is used to set new flags for the command
-func (c *Command) Flags() *flag.FlagSet {
-	return c.cobra.PersistentFlags()
-}
-
-// BindFlags needs to be called after all flags for a command have been defined
-func (c *Command) BindFlags() {
-	c.Flags().VisitAll(func(f *flag.Flag) {
-		myFlags.BindPFlag(f.Name, f)
-		myFlags.SetDefault(f.Name, f.DefValue)
-	})
-}
 
 // commands is a set of commands
 type commands map[string]*Command
@@ -214,27 +76,6 @@ func NewCli(n string) *Cli {
 	}
 	myFlags = viper.New()
 	return &c
-}
-
-// NewCommand returns a brand new command attached to it's parent cli
-func (c *Cli) NewCommand(n string) *Command {
-	cmd := &Command{
-		name:  n,
-		cobra: &cobra.Command{Use: n},
-	}
-	c.cmds[n] = cmd
-
-	cmd.setPreRun(func(c *cobra.Command, args []string) {
-		// PreRun function is optional
-		if cmd.RunTask.init != nil {
-			cmd.RunTask.init(cmd.RunTask, args)
-		}
-	})
-	cmd.setRun(func(c *cobra.Command, args []string) {
-		cmd.RunTask.f(cmd.RunTask, args)
-	})
-	c.cobra.AddCommand(cmd.cobra)
-	return cmd
 }
 
 // FlagValues returns the wrapped viper object allowing the API consumer to use methods

--- a/command.go
+++ b/command.go
@@ -1,0 +1,93 @@
+package cali
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// command is the actual command run by the cli and essentially just wraps cobra.Command and
+// has an associated Task
+type Command struct {
+	name    string
+	RunTask *Task
+	cobra   *cobra.Command
+}
+
+// Command returns a brand new command attached to it's parent cli
+func (c *Cli) NewCommand(n string) *Command {
+	cmd := newCommand(n)
+	c.cmds[n] = cmd
+	cmd.setPreRun(func(c *cobra.Command, args []string) {
+		cmd.RunTask.init(cmd.RunTask, args)
+	})
+	cmd.setRun(func(c *cobra.Command, args []string) {
+		cmd.RunTask.f(cmd.RunTask, args)
+	})
+	c.cobra.AddCommand(cmd.cobra)
+	return cmd
+}
+
+// newCommand returns an freshly initialised command
+func newCommand(n string) *Command {
+	return &Command{
+		name:  n,
+		cobra: &cobra.Command{Use: n},
+	}
+}
+
+// SetShort sets the short description of the command
+func (c *Command) SetShort(s string) {
+	c.cobra.Short = s
+}
+
+// SetLong sets the long description of the command
+func (c *Command) SetLong(l string) {
+	c.cobra.Long = l
+}
+
+// setPreRun sets the cobra.Command.PreRun function
+func (c *Command) setPreRun(f cobraFunc) {
+	c.cobra.PreRun = f
+}
+
+// setRun sets the cobra.Command.Run function
+func (c *Command) setRun(f cobraFunc) {
+	c.cobra.Run = f
+}
+
+// Task is something executed by a command
+func (c *Command) Task(def interface{}) *Task {
+	t := &Task{DockerClient: NewDockerClient()}
+
+	switch d := def.(type) {
+	case string:
+		t.SetImage(d)
+		t.SetFunc(defaultTaskFunc)
+	case TaskFunc:
+		t.SetFunc(d)
+	default:
+		// Slightly unidiomatic to blow up here rather than return an error
+		// choosing to so as to keep the API uncluttered and also if you get here it's
+		// an implementation error rather than a runtime error.
+		fmt.Println("Unknown Task type. Must either be an image (string) or a TaskFunc")
+		os.Exit(EXIT_CODE_API_ERROR)
+	}
+	c.RunTask = t
+	return t
+}
+
+// Flags returns the FlagSet for the command and is used to set new flags for the command
+func (c *Command) Flags() *pflag.FlagSet {
+	return c.cobra.PersistentFlags()
+}
+
+// BindFlags needs to be called after all flags for a command have been defined
+func (c *Command) BindFlags() {
+	c.Flags().VisitAll(func(f *pflag.Flag) {
+		myFlags.BindPFlag(f.Name, f)
+		myFlags.SetDefault(f.Name, f.DefValue)
+	})
+}

--- a/task.go
+++ b/task.go
@@ -1,0 +1,81 @@
+package cali
+
+import (
+	"strings"
+	"os/user"
+	"fmt"
+	"path/filepath"
+)
+
+// Task is the action performed when it's parent command is run
+type Task struct {
+	f, init TaskFunc
+	*DockerClient
+}
+
+// SetFunc sets the TaskFunc which is run when the parent command is run
+// if this is left unset, the defaultTaskFunc will be executed instead
+func (t *Task) SetFunc(f TaskFunc) {
+	t.f = f
+}
+
+// SetInitFunc sets the TaskFunc which is executed before the main TaskFunc. It's
+// pupose is to do any setup of the DockerClient which depends on command line args
+// for example
+func (t *Task) SetInitFunc(f TaskFunc) {
+	t.init = f
+}
+
+// SetDefaults sets the default host config for a task container
+// Mounts the PWD to /tmp/workspace
+// Mounts your ~/.aws directory to /root - change this if your image runs as a non-root user
+// Sets /tmp/workspace as the workdir
+// Configures git
+func (t *Task) SetDefaults(args []string) error {
+	t.SetWorkDir(workdir)
+	awsDir, err := t.Bind("~/.aws", "/root/.aws")
+	if err != nil {
+		return err
+	}
+	t.AddBinds([]string{awsDir})
+
+	err = t.BindFromGit(gitCfg, func() error {
+		pwd, err := t.Bind("./", workdir)
+		if err != nil {
+			return err
+		}
+		t.AddBinds([]string{pwd})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	t.SetCmd(args)
+	return nil
+}
+
+// Bind is a utility function which will return the correctly formatted string when given a source
+// and destination directory
+//
+// The ~ symbol and relative paths will be correctly expanded depending on the host OS
+func (t *Task) Bind(src, dst string) (string, error) {
+	var expanded string
+
+	if strings.HasPrefix(src, "~") {
+		usr, err := user.Current()
+
+		if err != nil {
+			return expanded, fmt.Errorf("Error expanding bind path: %s")
+		}
+		expanded = filepath.Join(usr.HomeDir, src[2:])
+	} else {
+		expanded = src
+	}
+	expanded, err := filepath.Abs(expanded)
+
+	if err != nil {
+		return expanded, fmt.Errorf("Error expanding bind path: %s")
+	}
+	return fmt.Sprintf("%s:%s", expanded, dst), nil
+}
+


### PR DESCRIPTION
This is an initial split of some of the classes into individual files for cleanup and to reduce file length.

I have advanced this idea moving docker functionality to a separated module/library to split it from the cali API.

This is just an initial step.