### PR TITLE
Fix some of the issues flagged up by TravisCI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [Unreleased]: https://github.com/skybet/cali/compare/v0.1.1...master
 ## [Unreleased]
 
+- Mostly refactoring at this point
+
 
 
 [0.1.1]:      https://github.com/skybet/cali/compare/v0.1.0...v0.1.1

--- a/task.go
+++ b/task.go
@@ -84,7 +84,7 @@ func (t *Task) Bind(src, dst string) (string, error) {
 		usr, err := user.Current()
 
 		if err != nil {
-			return expanded, fmt.Errorf("Error expanding bind path: %s")
+			return expanded, fmt.Errorf("Error expanding bind path: %s", err)
 		}
 		expanded = filepath.Join(usr.HomeDir, src[2:])
 	} else {
@@ -93,7 +93,7 @@ func (t *Task) Bind(src, dst string) (string, error) {
 	expanded, err := filepath.Abs(expanded)
 
 	if err != nil {
-		return expanded, fmt.Errorf("Error expanding bind path: %s")
+		return expanded, fmt.Errorf("Error expanding bind path: %s", err)
 	}
 	return fmt.Sprintf("%s:%s", expanded, dst), nil
 }


### PR DESCRIPTION
https://github.com/skybet/cali/pull/27 added a lot of great stuff, running in TravisCI

And that flagged up some issues:
https://travis-ci.org/skybet/cali/jobs/360289623


```
The command "go test -v -race ./..." exited with 2.
0.86s$ go vet ./...
# github.com/skybet/cali
./task.go:87: Errorf format %s reads arg #1, but call has only 0 args
./task.go:96: Errorf format %s reads arg #1, but call has only 0 args
```
^ Fixed

```
The command "go vet ./..." exited with 2.
21.33s$ megacheck ./...
docker.go:205:20: os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)
docker.go:241:3: should check returned error before deferring hijack.Conn.Close() (SA5001)
docker.go:322:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
docker.go:48:2: field running is unused (U1000)
```
^ Not fixed, but looks like it shouldn't be hard

```
The command "megacheck ./..." exited with 1.
0.01s$ gocyclo -over 19 $GO_FILES
```
^ Not sure what's going on with this

```
The command "golint -set_exit_status $(go list ./...)" exited with 1.
```
^ Not sure what's going on with this either