### PR TITLE
change logic to only call PullImage if necessary, and PullImage always pulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-[Unreleased]: https://github.com/skybet/cali/compare/v0.1.1...master
+[Unreleased]: https://github.com/skybet/cali/compare/v0.1.2...master
 ## [Unreleased]
 
-
+[0.1.2]:      https://github.com/skybet/cali/compare/v0.1.1...v0.1.2
+## [0.1.2] - 2018-04-07
+### Fixed
+- PullImage now always pulls as should be expected
+- StartContainer now only calls PullImage when the image does not exist locally
 
 [0.1.1]:      https://github.com/skybet/cali/compare/v0.1.0...v0.1.1
 ## [0.1.1] - 2018-02-11


### PR DESCRIPTION
This is my partial solution for #3 .

`PullImage` now always pulls the image, regardless of whether it already exists.

`StartContainer` now only calls `PullImage` if the image does not already exist.

This allows us to call `PullImage` ourselves whenever we want to ensure a Docker image is up to date.

What's missing from this is an option to always attempt pulling a new version of the image in `StartContainer`.  This can be added in using @lucymhdavies 's global flags code in #3 if desired.