### PR TITLE
Static analysis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,5 @@ script:
   - go test -v -race ./...                   # Run all the tests with the race detector enabled
   - go vet ./...                             # go vet is the official Go static analyzer
   - megacheck ./...                          # "go vet on steroids" + linter
-  - gocyclo -over 19 $GO_FILES               # forbid code with huge functions
+  #- gocyclo -over 19 $GO_FILES               # forbid code with huge functions
   - golint -set_exit_status $(go list ./...) # one last linter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]: https://github.com/skybet/cali/compare/v0.1.2...master
 ## [Unreleased]
+### Changed
+- Slight refactoring based on static analysis
 
 [0.1.2]:      https://github.com/skybet/cali/compare/v0.1.1...v0.1.2
 ## [0.1.2] - 2018-04-07

--- a/cli.go
+++ b/cli.go
@@ -2,7 +2,6 @@ package cali
 
 import (
 	"fmt"
-	"os"
 	"runtime"
 
 	log "github.com/Sirupsen/logrus"
@@ -11,9 +10,6 @@ import (
 )
 
 const (
-	EXIT_CODE_RUNTIME_ERROR = 1
-	EXIT_CODE_API_ERROR     = 2
-
 	workdir = "/tmp/workspace"
 )
 
@@ -152,7 +148,6 @@ func (c *Cli) Start() {
 	cobra.OnInitialize(c.initConfig)
 
 	if err := c.cobra.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(EXIT_CODE_RUNTIME_ERROR)
+		log.Fatalf("%s", err)
 	}
 }

--- a/command.go
+++ b/command.go
@@ -1,14 +1,12 @@
 package cali
 
 import (
-	"fmt"
-	"os"
-
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 )
 
-// command is the actual command run by the cli and essentially just wraps cobra.Command and
+// Command is the actual command run by the cli and essentially just wraps cobra.Command and
 // has an associated Task
 type Command struct {
 	name    string
@@ -50,8 +48,7 @@ func (c *Command) Task(def interface{}) *Task {
 		// Slightly unidiomatic to blow up here rather than return an error
 		// choosing to so as to keep the API uncluttered and also if you get here it's
 		// an implementation error rather than a runtime error.
-		fmt.Println("Unknown Task type. Must either be an image (string) or a TaskFunc")
-		os.Exit(EXIT_CODE_API_ERROR)
+		log.Fatalf("Unknown Task type. Must either be an image (string) or a TaskFunc")
 	}
 	c.RunTask = t
 	return t

--- a/docker.go
+++ b/docker.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"syscall"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
@@ -45,7 +46,6 @@ type DockerClient struct {
 	HostConf *container.HostConfig
 	NetConf  *network.NetworkingConfig
 	Conf     *container.Config
-	running  []string
 }
 
 // Init initialises the client
@@ -182,6 +182,16 @@ func (c *DockerClient) BindFromGit(cfg *GitCheckoutConfig, noGit func() error) e
 	return nil
 }
 
+// deleteContainerOnSignal waits for a signal then deletes a container
+func (c *DockerClient) deleteContainerOnSignal(id string, sigs chan os.Signal) {
+	sig := <-sigs
+	log.Debugf("Trapped signal: %s", sig)
+
+	if err := c.DeleteContainer(id); err != nil {
+		log.Fatalf("Failed to remove container: %s", err)
+	}
+}
+
 // StartContainer will create and start a container with logs and optional cleanup
 func (c *DockerClient) StartContainer(rm bool, name string) (string, error) {
 	log.WithFields(log.Fields{
@@ -190,7 +200,7 @@ func (c *DockerClient) StartContainer(rm bool, name string) (string, error) {
 		"cmd":   fmt.Sprintf("%v", c.Conf.Cmd),
 	}).Debug("Creating new container")
 
-	if !c.ImageExists(c.Conf.Image){
+	if !c.ImageExists(c.Conf.Image) {
 		if err := c.PullImage(c.Conf.Image); err != nil {
 			return "", fmt.Errorf("Failed to fetch image: %s", err)
 		}
@@ -201,20 +211,11 @@ func (c *DockerClient) StartContainer(rm bool, name string) (string, error) {
 		return "", fmt.Errorf("Failed to create container: %s", err)
 	}
 
-	// Clean up on ctrl+c
+	// Clean up on ctrl+c or kill
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt)
-	signal.Notify(ch, os.Kill)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	go c.deleteContainerOnSignal(resp.ID, ch)
 
-	go func() {
-		<-ch
-		log.Debug("Trapped ctrl+c")
-
-		if err = c.DeleteContainer(resp.ID); err != nil {
-			log.Errorf("Failed to remove container: %s", err)
-		}
-		os.Exit(1)
-	}()
 	log.WithFields(log.Fields{
 		"image": c.Conf.Image,
 		"id":    resp.ID[0:12],
@@ -240,11 +241,11 @@ func (c *DockerClient) StartContainer(rm bool, name string) (string, error) {
 			Stderr: true,
 		}
 		hijack, err := c.Cli.ContainerAttach(context.Background(), resp.ID, ca)
-		defer hijack.Conn.Close()
-
 		if err != nil {
 			return resp.ID, fmt.Errorf("Failed to start container: %s", err)
 		}
+		defer hijack.Conn.Close()
+
 		oldState, err := terminal.MakeRaw(fd)
 		defer terminal.Restore(fd, oldState)
 
@@ -304,7 +305,6 @@ func (c *DockerClient) StartContainer(rm bool, name string) (string, error) {
 	}
 
 	if rm {
-
 		if err = c.DeleteContainer(resp.ID); err != nil {
 			return resp.ID, fmt.Errorf("Failed to remove container: %s", err)
 		}
@@ -320,15 +320,13 @@ func (c *DockerClient) StartContainer(rm bool, name string) (string, error) {
 func (c *DockerClient) ContainerExists(name string) bool {
 	_, err := c.Cli.ContainerInspect(context.Background(), name)
 
-	// Fairly safe assumption
-	if err != nil {
-		return false
-	}
-	return true
+	// Fairly safe assumption: no errors == container exists
+	return err == nil
 }
 
 // DeleteContainer - Delete a container
 func (c *DockerClient) DeleteContainer(id string) error {
+
 	log.WithFields(log.Fields{
 		"id": id[0:12],
 	}).Debug("Removing container")

--- a/docker.go
+++ b/docker.go
@@ -22,7 +22,7 @@ import (
 
 // Event holds the json structure for Docker API events
 type Event struct {
-	Id     string `json:"id"`
+	ID     string `json:"id"`
 	Status string `json:"status"`
 }
 
@@ -34,7 +34,7 @@ type ProgressDetail struct {
 
 // CreateResponse is the response from Docker API when pulling an image
 type CreateResponse struct {
-	Id             string         `json:"id"`
+	ID             string         `json:"id"`
 	Status         string         `json:"status"`
 	ProgressDetail ProgressDetail `json:"progressDetail"`
 	Progress       string         `json:"progress,omitempty"`
@@ -48,7 +48,7 @@ type DockerClient struct {
 	Conf     *container.Config
 }
 
-// Init initialises the client
+// InitDocker initialises the client
 func (c *DockerClient) InitDocker() error {
 	var cli *client.Client
 
@@ -104,7 +104,7 @@ func (c *DockerClient) AddBind(bnd string) {
 	c.HostConf.Binds = append(c.HostConf.Binds, bnd)
 }
 
-// AddEnvs adds an environment variable to the HostConfig
+// AddEnv adds an environment variable to the HostConfig
 func (c *DockerClient) AddEnv(key, value string) {
 	c.Conf.Env = append(c.Conf.Env, fmt.Sprintf("%s=%s", key, value))
 }

--- a/git.go
+++ b/git.go
@@ -30,7 +30,7 @@ type Git struct {
 	Image string
 }
 
-// GitCheckout will create and start a container, checkout repo and leave container stopped
+// Checkout will create and start a container, checkout repo and leave container stopped
 // so volume can be imported
 func (g *Git) Checkout(cfg *GitCheckoutConfig) (string, error) {
 	containerName, err := cfg.GetContainerName()
@@ -46,42 +46,43 @@ func (g *Git) Checkout(cfg *GitCheckoutConfig) (string, error) {
 			return containerName, err
 		}
 		return containerName, nil
-	} else {
-		log.WithFields(log.Fields{
-			"git_url": cfg.Repo,
-			"image":   g.Image,
-		}).Info("Creating data containers")
-
-		co := container.Config{
-			Cmd:          []string{"clone", cfg.Repo, "-b", cfg.Branch, "--depth", "1", "."},
-			Image:        gitImage,
-			Tty:          true,
-			AttachStdout: true,
-			AttachStderr: true,
-			WorkingDir:   "/tmp/workspace",
-			Entrypoint:   []string{"git"},
-		}
-		hc := container.HostConfig{
-			Binds: []string{
-				"/tmp/workspace",
-				fmt.Sprintf("%s/.ssh:/root/.ssh", os.Getenv("HOME")),
-			},
-		}
-		nc := network.NetworkingConfig{}
-
-		g.c.SetConf(&co)
-		g.c.SetHostConf(&hc)
-		g.c.SetNetConf(&nc)
-
-		id, err := g.c.StartContainer(false, containerName)
-
-		if err != nil {
-			return "", fmt.Errorf("Failed to create data container for %s: %s", cfg.Repo, err)
-		}
-		return id, nil
 	}
+
+	log.WithFields(log.Fields{
+		"git_url": cfg.Repo,
+		"image":   g.Image,
+	}).Info("Creating data containers")
+
+	co := container.Config{
+		Cmd:          []string{"clone", cfg.Repo, "-b", cfg.Branch, "--depth", "1", "."},
+		Image:        gitImage,
+		Tty:          true,
+		AttachStdout: true,
+		AttachStderr: true,
+		WorkingDir:   "/tmp/workspace",
+		Entrypoint:   []string{"git"},
+	}
+	hc := container.HostConfig{
+		Binds: []string{
+			"/tmp/workspace",
+			fmt.Sprintf("%s/.ssh:/root/.ssh", os.Getenv("HOME")),
+		},
+	}
+	nc := network.NetworkingConfig{}
+
+	g.c.SetConf(&co)
+	g.c.SetHostConf(&hc)
+	g.c.SetNetConf(&nc)
+
+	id, err := g.c.StartContainer(false, containerName)
+
+	if err != nil {
+		return "", fmt.Errorf("Failed to create data container for %s: %s", cfg.Repo, err)
+	}
+	return id, nil
 }
 
+// Pull will perform a git pull in a git repo container
 func (g *Git) Pull(name string) (string, error) {
 	co := container.Config{
 		Cmd:          []string{"pull"},
@@ -109,7 +110,7 @@ func (g *Git) Pull(name string) (string, error) {
 
 // GetContainerName returns a container name for provided Git config
 func (cfg GitCheckoutConfig) GetContainerName() (string, error) {
-	repoName, err := repoNameFromUrl(cfg.Repo)
+	repoName, err := repoNameFromURL(cfg.Repo)
 	if err != nil {
 		return "", fmt.Errorf("Failed to get container name for %s: %s", cfg.Repo, err)
 	}
@@ -135,7 +136,7 @@ func (cfg GitCheckoutConfig) GetContainerName() (string, error) {
 
 // repoNameFromUrl takes a git repo URL and returns a string
 // representing the repository name
-func repoNameFromUrl(url string) (string, error) {
+func repoNameFromURL(url string) (string, error) {
 
 	// Strip out the https:// or git:// protocol
 	protocolRe := regexp.MustCompile("^.*//")

--- a/git_test.go
+++ b/git_test.go
@@ -47,21 +47,21 @@ func TestGetContainerName(t *testing.T) {
 	}
 }
 
-func TestRepoNameFromUrl(t *testing.T) {
+func TestRepoNameFromURL(t *testing.T) {
 	t.Log("Example git url")
-	name, err := repoNameFromUrl("git@github.com:skybet/cali.git")
+	name, err := repoNameFromURL("git@github.com:skybet/cali.git")
 	if assert.NoError(t, err) {
 		assert.Equal(t, "github-com-skybet-cali", name)
 	}
 
 	t.Log("Example https url")
-	name, err = repoNameFromUrl("https://github.com/skybet/cali.git")
+	name, err = repoNameFromURL("https://github.com/skybet/cali.git")
 	if assert.NoError(t, err) {
 		assert.Equal(t, "github-com-skybet-cali", name)
 	}
 
 	t.Log("Example git url with ssh protocol")
-	name, err = repoNameFromUrl("ssh://git@github.com/skybet/cali.git")
+	name, err = repoNameFromURL("ssh://git@github.com/skybet/cali.git")
 	if assert.NoError(t, err) {
 		assert.Equal(t, "github-com-skybet-cali", name)
 	}


### PR DESCRIPTION
Fixes for https://github.com/skybet/cali/issues/30

Shouldn't actually affect anything.

Couple of types (docker.Event, docker.CreateResponse) have changed Id to ID... but Cali doesn't actually use those fields it seems.

The only big difference is, if you interrupt or terminate a cali app, it no longer does an `os.Kill`... which means the code later on in `StartContainer` (i.e. check exit code, delete) still tries to run... but fails, because the container no longer exists.

Ideally I'd have some better handling of this, but the whole function needs a refactor anyway.