### PR TITLE
Auto-detect if host is terminal, and use that to determine if we should run non-interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - DockerClient.InitDocker does nothing if Docker client was previously initialised
 - All DockerClient methods which rely on an initialised Docker client now run InitDocker. As a result, a few DockerClient methods now have the possibilities of returning errors: ContainerExists, ImageExists
 - Auto-detects whether host process is a terminal, and uses that to automatically decide whether to run container non-interactive
+- If running non-interactive, disable TTY on container
 
 [0.1.2]:      https://github.com/skybet/cali/compare/v0.1.1...v0.1.2
 ## [0.1.2] - 2018-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Slight refactoring based on static analysis
 - DockerClient.InitDocker does nothing if Docker client was previously initialised
 - All DockerClient methods which rely on an initialised Docker client now run InitDocker. As a result, a few DockerClient methods now have the possibilities of returning errors: ContainerExists, ImageExists
+- Auto-detects whether host process is a terminal, and uses that to automatically decide whether to run container non-interactive
 
 [0.1.2]:      https://github.com/skybet/cali/compare/v0.1.1...v0.1.2
 ## [0.1.2] - 2018-04-07

--- a/docker.go
+++ b/docker.go
@@ -238,7 +238,7 @@ func (c *DockerClient) StartContainer(rm bool, name string) (string, error) {
 	// Set the TTY size to match the host terminal
 	fd := int(os.Stdin.Fd())
 
-	if !nonInteractive && terminal.IsTerminal(fd) {
+	if !nonInteractive && terminal.IsTerminal(int(os.Stdout.Fd())) {
 		// While we have a container running, create a buffer for the pscli logs
 		logBuffer := bufio.NewWriter(os.Stdout)
 		log.SetOutput(logBuffer)

--- a/docker.go
+++ b/docker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/net/context"
 	pb "gopkg.in/cheggaaa/pb.v1"
@@ -219,6 +220,11 @@ func (c *DockerClient) StartContainer(rm bool, name string) (string, error) {
 			return "", fmt.Errorf("Failed to fetch image: %s", err)
 		}
 	}
+
+	// Disable TTY if we're non-interactive, or if we're not in a terminal
+	if nonInteractive || !terminal.IsTerminal(int(os.Stdout.Fd())) {
+		c.Conf.Tty = false
+	}
 	resp, err := c.Cli.ContainerCreate(context.Background(), c.Conf, c.HostConf, c.NetConf, name)
 
 	if err != nil {
@@ -237,6 +243,11 @@ func (c *DockerClient) StartContainer(rm bool, name string) (string, error) {
 
 	// Set the TTY size to match the host terminal
 	fd := int(os.Stdin.Fd())
+
+	// TODO: I would argue that, at some point, we change this behaviour to be more inline with Docker:
+	// -i interactive - default true if in a terminal, or if we're piping stuff in with stdin
+	// -t tty         - default true if in a terminal
+	// But given Cali doesn't currently support piping stuff in from stdin... not important yet
 
 	if !nonInteractive && terminal.IsTerminal(int(os.Stdout.Fd())) {
 		// While we have a container running, create a buffer for the pscli logs
@@ -332,7 +343,7 @@ func (c *DockerClient) startContainerNonInteractive(containerID string) error {
 		return fmt.Errorf("Failed to get container logs: %s", err)
 	}
 
-	_, err = io.Copy(os.Stdout, containerLogs)
+	_, err = stdcopy.StdCopy(os.Stdout, os.Stderr, containerLogs)
 	if err != nil {
 		return fmt.Errorf("Failed to get container logs: %s", err)
 	}


### PR DESCRIPTION
Using `lucli vault` to test this.

https://github.com/LMHD/lucli/blob/master/cmd/vault.go

e.g. a container run without this change:

```
$ lucli vault read -- -field=display_name auth/token/lookup | od -c
0000000  033   [   0   m   l   d   a   p   -   d   a   v   i   e   s   l
                                                                        0000020  033   [   0   m  \r  \n
0000026
```

Compared to a container run with the change:

```
$ luclidev vault read -- -field=display_name auth/token/lookup | od -c
0000000  033   [   0   m   l   d   a   p   -   d   a   v   i   e   s   l
0000020  033   [   0   m  \r  \n
0000026
```

I don't know _why_ using stdout for this works, but stdin does not. But it does, so that's good enough for me.


Partial resolution of https://github.com/skybet/cali/issues/45


Still not quite there yet.

Compared to running the container directly:

```
0000000    l   d   a   p   -   d   a   v   i   e   s   l
0000014
```