### PR TITLE
Remove auto-mount of aws credentials

### DIFF
--- a/task.go
+++ b/task.go
@@ -49,13 +49,8 @@ func (t *Task) SetInitFunc(f TaskFunc) {
 // Configures git
 func (t *Task) SetDefaults(args []string) error {
 	t.SetWorkDir(workdir)
-	awsDir, err := t.Bind("~/.aws", "/root/.aws")
-	if err != nil {
-		return err
-	}
-	t.AddBinds([]string{awsDir})
 
-	err = t.BindFromGit(gitCfg, func() error {
+	err := t.BindFromGit(gitCfg, func() error {
 		pwd, err := t.Bind("./", workdir)
 		if err != nil {
 			return err


### PR DESCRIPTION
This solves half of #7 

The reason for me implementing this, is that the current `~ expansion logic` is hard to make work in a cross-compilation setup, eg when compiling the binary and putting in a Dockerfile with `FROM scratch`. This is due to the use of `user.Current()`.

I have run the tests, dunno if there should be a new one?

I can produce a minimal example where it "breaks", if anyone is interested? :-)

Have a nice day.